### PR TITLE
added filelock support to avoid collision while writing logs

### DIFF
--- a/core/log.py
+++ b/core/log.py
@@ -65,15 +65,12 @@ def sort_logs(log_in_file, language, graph_flag):
                                                    value['PORT'], value['TYPE'], value['DESCRIPTION'], value['TIME'])
         _table += _log_data.table_end + '<p class="footer">' + messages(language, 93) \
             .format(compatible.__version__, compatible.__code_name__, now()) + '</p>'
-        _table = _table.encode('utf8')
-        save = open(log_in_file, 'w' if type(_table) == str else 'wb')
-        save.write(_table)
-        save.close()
+        __log_into_file(log_in_file, 'w' if type(_table) == str else 'wb', table)
+
+
     elif len(log_in_file) >= 5 and log_in_file[-5:] == '.json':
         data = json.dumps(sorted(json.loads('[' + _get_log_values(log_in_file) + ']')))
-        save = open(log_in_file, 'wb')
-        save.write(data.encode('utf8'))
-        save.close()
+        __log_into_file(log_in_file, 'wb', data)
     else:
         data = sorted(json.loads('[' + _get_log_values(log_in_file) + ']'))
         _table = texttable.Texttable()
@@ -82,9 +79,14 @@ def sort_logs(log_in_file, language, graph_flag):
             _table.add_rows([[_HOST, _USERNAME, _PASSWORD, _PORT, _TYPE, _DESCRIPTION, _TIME],
                              [value['HOST'], value['USERNAME'], value['PASSWORD'], value['PORT'], value['TYPE'],
                               value['DESCRIPTION'], value['TYPE']]])
-        save = open(log_in_file, 'wb')
-        save.write(_table.draw().encode('utf8') + '\n\n' +
+        data = _table.draw().encode('utf8') + '\n\n' +
                    messages(language, 93).format(compatible.__version__, compatible.__code_name__,
-                                                 now()).encode('utf8') + '\n\n')
-        save.close()
+                                                 now()).encode('utf8') + '\n\n'
+        __log_into_file(log_in_file, 'wb', data)
     return 0
+
+def __log_into_file(filename, mode, data):
+    flock.acquire()
+    with open(filename, mode) as save:
+        save.write(data + '\n')
+    flock.release()

--- a/core/log.py
+++ b/core/log.py
@@ -79,17 +79,17 @@ def sort_logs(log_in_file, language, graph_flag):
             _table.add_rows([[_HOST, _USERNAME, _PASSWORD, _PORT, _TYPE, _DESCRIPTION, _TIME],
                              [value['HOST'], value['USERNAME'], value['PASSWORD'], value['PORT'], value['TYPE'],
                               value['DESCRIPTION'], value['TYPE']]])
-        data = _table.draw().encode('utf8') + '\n\n' 
+        data = _table.draw().encode('utf8') + '\n\n'
         + messages(language, 93).format(compatible.__version__, compatible.__code_name__,
                                                  now()).encode('utf8')
         __log_into_file(log_in_file, 'wb', data)
     return 0
 
 def __log_into_file(filename, mode, data):
-    
+
     if filename not in write_blocks:
-        flock = lockfile.FileLock(filename)
         write_blocks.append(filename)
+        flock = lockfile.FileLock(filename)
 
     flock.acquire()
     with open(filename, mode) as save:

--- a/core/log.py
+++ b/core/log.py
@@ -10,6 +10,9 @@ from core.alert import error
 from core import compatible
 from core._time import now
 from core._die import __die_failure
+import lockfile
+
+flock = lockfile.FileLock('log.txt')
 
 
 def build_graph(graph_flag, language, data, _HOST, _USERNAME, _PASSWORD, _PORT, _TYPE, _DESCRIPTION):
@@ -65,9 +68,7 @@ def sort_logs(log_in_file, language, graph_flag):
                                                    value['PORT'], value['TYPE'], value['DESCRIPTION'], value['TIME'])
         _table += _log_data.table_end + '<p class="footer">' + messages(language, 93) \
             .format(compatible.__version__, compatible.__code_name__, now()) + '</p>'
-        __log_into_file(log_in_file, 'w' if type(_table) == str else 'wb', table)
-
-
+        __log_into_file(log_in_file, 'w' if type(_table) == str else 'wb', _table)
     elif len(log_in_file) >= 5 and log_in_file[-5:] == '.json':
         data = json.dumps(sorted(json.loads('[' + _get_log_values(log_in_file) + ']')))
         __log_into_file(log_in_file, 'wb', data)
@@ -79,9 +80,9 @@ def sort_logs(log_in_file, language, graph_flag):
             _table.add_rows([[_HOST, _USERNAME, _PASSWORD, _PORT, _TYPE, _DESCRIPTION, _TIME],
                              [value['HOST'], value['USERNAME'], value['PASSWORD'], value['PORT'], value['TYPE'],
                               value['DESCRIPTION'], value['TYPE']]])
-        data = _table.draw().encode('utf8') + '\n\n' +
-                   messages(language, 93).format(compatible.__version__, compatible.__code_name__,
-                                                 now()).encode('utf8') + '\n\n'
+        data = _table.draw().encode('utf8') + '\n\n' 
+        + messages(language, 93).format(compatible.__version__, compatible.__code_name__,
+                                                 now()).encode('utf8')
         __log_into_file(log_in_file, 'wb', data)
     return 0
 

--- a/core/log.py
+++ b/core/log.py
@@ -87,10 +87,7 @@ def sort_logs(log_in_file, language, graph_flag):
 
 def __log_into_file(filename, mode, data):
 
-    if filename not in write_blocks:
-        write_blocks.append(filename)
-        flock = lockfile.FileLock(filename)
-
+    flock = lockfile.FileLock(filename)
     flock.acquire()
     with open(filename, mode) as save:
         save.write(data + '\n')

--- a/core/log.py
+++ b/core/log.py
@@ -86,12 +86,6 @@ def sort_logs(log_in_file, language, graph_flag):
     return 0
 
 def __log_into_file(filename, mode, data):
-    flock.acquire()
-    with open(filename, mode) as save:
-        save.write(data + '\n')
-    flock.release()
-
-def __log_into_file(filename, mode, data):
     
     if filename not in write_blocks:
         flock = lockfile.FileLock(filename)

--- a/core/log.py
+++ b/core/log.py
@@ -12,8 +12,7 @@ from core._time import now
 from core._die import __die_failure
 import lockfile
 
-flock = lockfile.FileLock('log.txt')
-
+write_blocks = []
 
 def build_graph(graph_flag, language, data, _HOST, _USERNAME, _PASSWORD, _PORT, _TYPE, _DESCRIPTION):
     info(messages(language, 88))
@@ -87,6 +86,17 @@ def sort_logs(log_in_file, language, graph_flag):
     return 0
 
 def __log_into_file(filename, mode, data):
+    flock.acquire()
+    with open(filename, mode) as save:
+        save.write(data + '\n')
+    flock.release()
+
+def __log_into_file(filename, mode, data):
+    
+    if filename not in write_blocks:
+        flock = lockfile.FileLock(filename)
+        write_blocks.append(filename)
+
     flock.acquire()
     with open(filename, mode) as save:
         save.write(data + '\n')

--- a/core/log.py
+++ b/core/log.py
@@ -12,8 +12,6 @@ from core._time import now
 from core._die import __die_failure
 import lockfile
 
-write_blocks = []
-
 def build_graph(graph_flag, language, data, _HOST, _USERNAME, _PASSWORD, _PORT, _TYPE, _DESCRIPTION):
     info(messages(language, 88))
     try:

--- a/lib/brute/ftp/engine.py
+++ b/lib/brute/ftp/engine.py
@@ -75,14 +75,13 @@ def login(user, passwd, target, port, timeout_sec, log_in_file, language, retrie
             tmpl = []
             tmp = my_ftp.retrlines('LIST', tmpl.append)
             info(messages(language, 70).format(user, passwd, target, port))
-            data = 
-                json.dumps({'HOST': target, 'USERNAME': user, 'PASSWORD': passwd, 'PORT': port, 'TYPE': 'ftp_brute',
-                            'DESCRIPTION': messages(language, 66), 'TIME': now(), 'CATEGORY': "brute"})
+            data = json.dumps({'HOST': target, 'USERNAME': user, 'PASSWORD': passwd, 'PORT': port, 'TYPE': 'ftp_brute', 
+                'DESCRIPTION': messages(language, 66), 'TIME': now(), 'CATEGORY': "brute"})
             __log_into_file(log_in_file, 'a', data)
         except:
             info(messages(language, 70).format(user, passwd, target, port) + ' ' + messages(language, 71))
-            data = json.dumps({'HOST': target, 'USERNAME': user, 'PASSWORD': passwd, 'PORT': port, 'TYPE': 'FTP',
-                                   'DESCRIPTION': messages(language, 67), 'TIME': now(), 'CATEGORY': "brute"})
+            data = json.dumps({'HOST': target, 'USERNAME': user, 'PASSWORD': passwd, 'PORT': port, 'TYPE': 'FTP', 
+                'DESCRIPTION': messages(language, 67), 'TIME': now(), 'CATEGORY': "brute"})
             __log_into_file(log_in_file, 'a', data)
         __log_into_file(thread_tmp_filename, 'w', '0')
     else:
@@ -263,9 +262,9 @@ def start(target, users, passwds, ports, timeout_sec, thread_number, num, total,
                 break
         thread_write = int(open(thread_tmp_filename).read().rsplit()[0])
         if thread_write is 1 and verbose_level is not 0:
-            data = json.dumps({'HOST': target, 'USERNAME': '', 'PASSWORD': '', 'PORT': '', 'TYPE': 'ftp_brute',
-                                   'DESCRIPTION': messages(language, 95), 'TIME': now(), 'CATEGORY': "brute",
-                                   'SCAN_ID': scan_id, 'SCAN_CMD': scan_cmd})
+            data = json.dumps({'HOST': target, 'USERNAME': '', 'PASSWORD': '', 'PORT': '', 'TYPE': 'ftp_brute', 
+                'DESCRIPTION': messages(language, 95), 'TIME': now(), 'CATEGORY': "brute", 
+                'SCAN_ID': scan_id, 'SCAN_CMD': scan_cmd})
             __log_into_file(log_in_file, 'a', data)
         os.remove(thread_tmp_filename)
     else:

--- a/lib/brute/ftp/engine.py
+++ b/lib/brute/ftp/engine.py
@@ -16,6 +16,7 @@ from core.targets import target_to_host
 from lib.icmp.engine import do_one as do_one_ping
 from lib.socks_resolver.engine import getaddrinfo
 from core._time import now
+from core.log import __log_into_file
 
 
 def extra_requirements_dict():
@@ -74,20 +75,16 @@ def login(user, passwd, target, port, timeout_sec, log_in_file, language, retrie
             tmpl = []
             tmp = my_ftp.retrlines('LIST', tmpl.append)
             info(messages(language, 70).format(user, passwd, target, port))
-            save = open(log_in_file, 'a')
-            save.write(
+            data = 
                 json.dumps({'HOST': target, 'USERNAME': user, 'PASSWORD': passwd, 'PORT': port, 'TYPE': 'ftp_brute',
-                            'DESCRIPTION': messages(language, 66), 'TIME': now(), 'CATEGORY': "brute"}) + '\n')
-            save.close()
+                            'DESCRIPTION': messages(language, 66), 'TIME': now(), 'CATEGORY': "brute"})
+            __log_into_file(log_in_file, 'a', data)
         except:
             info(messages(language, 70).format(user, passwd, target, port) + ' ' + messages(language, 71))
-            save = open(log_in_file, 'a')
-            save.write(json.dumps({'HOST': target, 'USERNAME': user, 'PASSWORD': passwd, 'PORT': port, 'TYPE': 'FTP',
-                                   'DESCRIPTION': messages(language, 67), 'TIME': now(), 'CATEGORY': "brute"}) + '\n')
-            save.close()
-        thread_write = open(thread_tmp_filename, 'w')
-        thread_write.write('0')
-        thread_write.close()
+            data = json.dumps({'HOST': target, 'USERNAME': user, 'PASSWORD': passwd, 'PORT': port, 'TYPE': 'FTP',
+                                   'DESCRIPTION': messages(language, 67), 'TIME': now(), 'CATEGORY': "brute"})
+            __log_into_file(log_in_file, 'a', data)
+        __log_into_file(thread_tmp_filename, 'w', '0')
     else:
         pass
     return flag
@@ -125,9 +122,7 @@ def __connect_to_port(port, timeout_sec, target, retries, language, num, total, 
             if exit is retries:
                 error(messages(language, 68).format(target, port, str(num), str(total)))
                 try:
-                    f = open(ports_tmp_filename, 'a')
-                    f.write(str(port) + '\n')
-                    f.close()
+                    __log_into_file(ports_tmp_filename, 'a', str(port))
                 except:
                     pass
                 break
@@ -228,12 +223,8 @@ def start(target, users, passwds, ports, timeout_sec, thread_number, num, total,
             random.choice(string.ascii_letters + string.digits) for _ in range(20))
         ports_tmp_filename = 'tmp/ports_tmp_' + ''.join(
             random.choice(string.ascii_letters + string.digits) for _ in range(20))
-        thread_write = open(thread_tmp_filename, 'w')
-        thread_write.write('1')
-        thread_write.close()
-        ports_write = open(ports_tmp_filename, 'w')
-        ports_write.write('')
-        ports_write.close()
+        __log_into_file(thread_tmp_filename, 'w', '1')
+        __log_into_file(ports_tmp_filename, 'w', '')
         trying = 0
         ports = test_ports(ports, timeout_sec, target, retries, language, num, total, time_sleep, ports_tmp_filename,
                            thread_number, total_req, verbose_level, socks_proxy)
@@ -272,11 +263,10 @@ def start(target, users, passwds, ports, timeout_sec, thread_number, num, total,
                 break
         thread_write = int(open(thread_tmp_filename).read().rsplit()[0])
         if thread_write is 1 and verbose_level is not 0:
-            save = open(log_in_file, 'a')
-            save.write(json.dumps({'HOST': target, 'USERNAME': '', 'PASSWORD': '', 'PORT': '', 'TYPE': 'ftp_brute',
+            data = json.dumps({'HOST': target, 'USERNAME': '', 'PASSWORD': '', 'PORT': '', 'TYPE': 'ftp_brute',
                                    'DESCRIPTION': messages(language, 95), 'TIME': now(), 'CATEGORY': "brute",
-                                   'SCAN_ID': scan_id, 'SCAN_CMD': scan_cmd}) + '\n')
-            save.close()
+                                   'SCAN_ID': scan_id, 'SCAN_CMD': scan_cmd})
+            __log_into_file(log_in_file, 'a', data)
         os.remove(thread_tmp_filename)
     else:
         warn(messages(language, 69).format('ftp_brute', target))

--- a/lib/brute/smtp/engine.py
+++ b/lib/brute/smtp/engine.py
@@ -16,6 +16,7 @@ from core.targets import target_to_host
 from lib.icmp.engine import do_one as do_one_ping
 from lib.socks_resolver.engine import getaddrinfo
 from core._time import now
+from core.log import __log_into_file
 
 
 def extra_requirements_dict():
@@ -73,14 +74,11 @@ def login(user, passwd, target, port, timeout_sec, log_in_file, language, retrie
         pass
     if flag is 0:
         info(messages(language, 70).format(user, passwd, target, port))
-        save = open(log_in_file, 'a')
-        save.write(json.dumps({'HOST': target, 'USERNAME': user, 'PASSWORD': passwd, 'PORT': port, 'TYPE': 'smtp_brute',
+        data = json.dumps({'HOST': target, 'USERNAME': user, 'PASSWORD': passwd, 'PORT': port, 'TYPE': 'smtp_brute',
                                'DESCRIPTION': messages(language, 66), 'TIME': now(), 'CATEGORY': "brute",
-                               'SCAN_ID': scan_id, 'SCAN_CMD': scan_cmd}) + '\n')
-        save.close()
-        thread_write = open(thread_tmp_filename, 'w')
-        thread_write.write('0')
-        thread_write.close()
+                               'SCAN_ID': scan_id, 'SCAN_CMD': scan_cmd})
+        __log_into_file(log_in_file, 'a', data)
+        __log_into_file(thread_tmp_filename, 'w', '0')
     else:
         pass
     try:
@@ -124,9 +122,7 @@ def __connect_to_port(port, timeout_sec, target, retries, language, num, total, 
             if exit is retries:
                 error(messages(language, 74).format(target, port, str(num), str(total)))
                 try:
-                    f = open(ports_tmp_filename, 'a')
-                    f.write(str(port) + '\n')
-                    f.close()
+                    __log_into_file(ports_tmp_filename, 'a', str(port))
                 except:
                     pass
                 break
@@ -233,12 +229,8 @@ def start(target, users, passwds, ports, timeout_sec, thread_number, num, total,
             random.choice(string.ascii_letters + string.digits) for _ in range(20))
         ports_tmp_filename = 'tmp/ports_tmp_' + ''.join(
             random.choice(string.ascii_letters + string.digits) for _ in range(20))
-        thread_write = open(thread_tmp_filename, 'w')
-        thread_write.write('1')
-        thread_write.close()
-        ports_write = open(ports_tmp_filename, 'w')
-        ports_write.write('')
-        ports_write.close()
+        __log_into_file(thread_tmp_filename, 'w', '1')
+        __log_into_file(ports_tmp_filename, 'w', '')
         ports = test_ports(ports, timeout_sec, target, retries, language, num, total, time_sleep, ports_tmp_filename,
                            thread_number, total_req, verbose_level, socks_proxy)
         trying = 0
@@ -303,11 +295,10 @@ def start(target, users, passwds, ports, timeout_sec, thread_number, num, total,
                 break
         thread_write = int(open(thread_tmp_filename).read().rsplit()[0])
         if thread_write is 1 and verbose_level is not 0:
-            save = open(log_in_file, 'a')
-            save.write(json.dumps({'HOST': target, 'USERNAME': '', 'PASSWORD': '', 'PORT': '', 'TYPE': 'smtp_brute',
+            data = json.dumps({'HOST': target, 'USERNAME': '', 'PASSWORD': '', 'PORT': '', 'TYPE': 'smtp_brute',
                                    'DESCRIPTION': messages(language, 95), 'TIME': now(), 'CATEGORY': "brute",
-                                   'SCAN_ID': scan_id, 'SCAN_CMD': scan_cmd}) + '\n')
-            save.close()
+                                   'SCAN_ID': scan_id, 'SCAN_CMD': scan_cmd})
+            __log_into_file(log_in_file, 'a', data)
         os.remove(thread_tmp_filename)
     else:
         warn(messages(language, 69).format(target))

--- a/lib/brute/ssh/engine.py
+++ b/lib/brute/ssh/engine.py
@@ -17,6 +17,7 @@ from core.targets import target_to_host
 from lib.icmp.engine import do_one as do_one_ping
 from lib.socks_resolver.engine import getaddrinfo
 from core._time import now
+from core.log import __log_into_file
 
 
 def extra_requirements_dict():
@@ -74,14 +75,12 @@ def login(user, passwd, target, port, timeout_sec, log_in_file, language, retrie
                 ssh.connect(hostname=target, username=user, password=passwd, port=int(port))
             info(messages(language, 70).format(user, passwd, target, port))
             save = open(log_in_file, 'a')
-            save.write(
+            data = 
                 json.dumps({'HOST': target, 'USERNAME': user, 'PASSWORD': passwd, 'PORT': port, 'TYPE': 'ssh_brute',
                             'DESCRIPTION': messages(language, 66), 'TIME': now(), 'CATEGORY': "brute",
-                            'SCAN_ID': scan_id, 'SCAN_CMD': scan_cmd}) + '\n')
-            save.close()
-            thread_write = open(thread_tmp_filename, 'w')
-            thread_write.write('0')
-            thread_write.close()
+                            'SCAN_ID': scan_id, 'SCAN_CMD': scan_cmd})
+            __log_into_file(log_in_file, 'a', data)
+            __log_into_file(thread_tmp_filename, 'w', '0')
         except:
             pass
     else:
@@ -128,9 +127,7 @@ def __connect_to_port(port, timeout_sec, target, retries, language, num, total, 
                 if exit is retries:
                     error(messages(language, 77).format(target, port, str(num), str(total)))
                     try:
-                        f = open(ports_tmp_filename, 'a')
-                        f.write(str(port) + '\n')
-                        f.close()
+                        __log_into_file(ports_tmp_filename, 'a', str(port))
                     except:
                         pass
                     break
@@ -139,9 +136,7 @@ def __connect_to_port(port, timeout_sec, target, retries, language, num, total, 
             if exit is 3:
                 error(messages(language, 77).format(target, port, str(num), str(total)))
                 try:
-                    f = open(ports_tmp_filename, 'a')
-                    f.write(str(port) + '\n')
-                    f.close()
+                    __log_into_file(ports_tmp_filename, 'a', str(port))
                 except:
                     pass
                 break
@@ -255,12 +250,8 @@ def start(target, users, passwds, ports, timeout_sec, thread_number, num, total,
             random.choice(string.ascii_letters + string.digits) for _ in range(20))
         ports_tmp_filename = 'tmp/ports_tmp_' + ''.join(
             random.choice(string.ascii_letters + string.digits) for _ in range(20))
-        thread_write = open(thread_tmp_filename, 'w')
-        thread_write.write('1')
-        thread_write.close()
-        ports_write = open(ports_tmp_filename, 'w')
-        ports_write.write('')
-        ports_write.close()
+        __log_into_file(threads_tmp_filename, 'w', '1')
+        __log_into_file(ports_tmp_filename, 'w', '')
         trying = 0
         ports = test_ports(ports, timeout_sec, target, retries, language, num, total, time_sleep, ports_tmp_filename,
                            thread_number, total_req, verbose_level, socks_proxy)
@@ -302,11 +293,10 @@ def start(target, users, passwds, ports, timeout_sec, thread_number, num, total,
                 break
         thread_write = int(open(thread_tmp_filename).read().rsplit()[0])
         if thread_write is 1 and verbose_level is not 0:
-            save = open(log_in_file, 'a')
-            save.write(json.dumps({'HOST': target, 'USERNAME': '', 'PASSWORD': '', 'PORT': '', 'TYPE': 'ssh_brute',
+            data = json.dumps({'HOST': target, 'USERNAME': '', 'PASSWORD': '', 'PORT': '', 'TYPE': 'ssh_brute',
                                    'DESCRIPTION': messages(language, 95), 'TIME': now(), 'CATEGORY': "brute",
-                                   'SCAN_ID': scan_id, 'SCAN_CMD': scan_cmd}) + '\n')
-            save.close()
+                                   'SCAN_ID': scan_id, 'SCAN_CMD': scan_cmd})
+            __log_into_file(log_in_file, 'a', data)
         os.remove(thread_tmp_filename)
     else:
         warn(messages(language, 69).format('ssh_brute', target))

--- a/lib/brute/ssh/engine.py
+++ b/lib/brute/ssh/engine.py
@@ -75,10 +75,9 @@ def login(user, passwd, target, port, timeout_sec, log_in_file, language, retrie
                 ssh.connect(hostname=target, username=user, password=passwd, port=int(port))
             info(messages(language, 70).format(user, passwd, target, port))
             save = open(log_in_file, 'a')
-            data = 
-                json.dumps({'HOST': target, 'USERNAME': user, 'PASSWORD': passwd, 'PORT': port, 'TYPE': 'ssh_brute',
-                            'DESCRIPTION': messages(language, 66), 'TIME': now(), 'CATEGORY': "brute",
-                            'SCAN_ID': scan_id, 'SCAN_CMD': scan_cmd})
+            data = json.dumps({'HOST': target, 'USERNAME': user, 'PASSWORD': passwd, 'PORT': port, 'TYPE': 'ssh_brute', 
+                'DESCRIPTION': messages(language, 66), 'TIME': now(), 'CATEGORY': "brute", 
+                'SCAN_ID': scan_id, 'SCAN_CMD': scan_cmd})
             __log_into_file(log_in_file, 'a', data)
             __log_into_file(thread_tmp_filename, 'w', '0')
         except:
@@ -293,9 +292,9 @@ def start(target, users, passwds, ports, timeout_sec, thread_number, num, total,
                 break
         thread_write = int(open(thread_tmp_filename).read().rsplit()[0])
         if thread_write is 1 and verbose_level is not 0:
-            data = json.dumps({'HOST': target, 'USERNAME': '', 'PASSWORD': '', 'PORT': '', 'TYPE': 'ssh_brute',
-                                   'DESCRIPTION': messages(language, 95), 'TIME': now(), 'CATEGORY': "brute",
-                                   'SCAN_ID': scan_id, 'SCAN_CMD': scan_cmd})
+            data = json.dumps({'HOST': target, 'USERNAME': '', 'PASSWORD': '', 'PORT': '', 'TYPE': 'ssh_brute', 
+                'DESCRIPTION': messages(language, 95), 'TIME': now(), 'CATEGORY': "brute", 
+                'SCAN_ID': scan_id, 'SCAN_CMD': scan_cmd})
             __log_into_file(log_in_file, 'a', data)
         os.remove(thread_tmp_filename)
     else:

--- a/lib/brute/ssh/engine.py
+++ b/lib/brute/ssh/engine.py
@@ -249,7 +249,7 @@ def start(target, users, passwds, ports, timeout_sec, thread_number, num, total,
             random.choice(string.ascii_letters + string.digits) for _ in range(20))
         ports_tmp_filename = 'tmp/ports_tmp_' + ''.join(
             random.choice(string.ascii_letters + string.digits) for _ in range(20))
-        __log_into_file(threads_tmp_filename, 'w', '1')
+        __log_into_file(thread_tmp_filename, 'w', '1')
         __log_into_file(ports_tmp_filename, 'w', '')
         trying = 0
         ports = test_ports(ports, timeout_sec, target, retries, language, num, total, time_sleep, ports_tmp_filename,

--- a/lib/scan/dir/engine.py
+++ b/lib/scan/dir/engine.py
@@ -83,19 +83,19 @@ def check(target, user_agent, timeout_sec, log_in_file, language, time_sleep, th
         if r.status_code in status_codes:
             info(messages(language, 38).format(target, r.status_code, r.reason))
             __log_into_file(thread_tmp_filename, 'w', '0')
-            data = json.dumps({'HOST': target_to_host(target), 'USERNAME': '', 'PASSWORD': '',
-                                   'PORT': int(target.rsplit(':')[2].rsplit('/')[0]), 'TYPE': 'dir_scan',
-                                   'DESCRIPTION': messages(language, 38).format(target, r.status_code, r.reason),
-                                   'TIME': now(), 'CATEGORY': "scan", 'SCAN_ID': scan_id, 'SCAN_CMD': scan_cmd})
+            data = json.dumps({'HOST': target_to_host(target), 'USERNAME': '', 'PASSWORD': '', 
+                'PORT': int(target.rsplit(':')[2].rsplit('/')[0]), 'TYPE': 'dir_scan', 
+                'DESCRIPTION': messages(language, 38).format(target, r.status_code, r.reason), 
+                'TIME': now(), 'CATEGORY': "scan", 'SCAN_ID': scan_id, 'SCAN_CMD': scan_cmd})
             __log_into_file(log_in_file, 'a', data)
             if r.status_code is 200:
                 for dlmsg in directory_listing_msgs:
                     if dlmsg in content:
                         info(messages(language, 104).format(target))
-                        data = json.dumps({'HOST': target_to_host(target), 'USERNAME': '', 'PASSWORD': '',
-                                               'PORT': int(target.rsplit(':')[1].rsplit('/')[0]), 'TYPE': 'dir_scan',
-                                               'DESCRIPTION': messages(language, 104).format(target), 'TIME': now(),
-                                               'CATEGORY': "scan", 'SCAN_ID': scan_id, 'SCAN_CMD': scan_cmd})
+                        data = json.dumps({'HOST': target_to_host(target), 'USERNAME': '', 'PASSWORD': '', 
+                            'PORT': int(target.rsplit(':')[1].rsplit('/')[0]), 'TYPE': 'dir_scan', 
+                            'DESCRIPTION': messages(language, 104).format(target), 'TIME': now(), 
+                            'CATEGORY': "scan", 'SCAN_ID': scan_id, 'SCAN_CMD': scan_cmd})
                         __log_into_file(log_in_file, 'a', data)
                         break
         return True
@@ -267,9 +267,9 @@ def start(target, users, passwds, ports, timeout_sec, thread_number, num, total,
         if thread_write is 1:
             info(messages(language, 108).format(target, ",".join(map(str, ports))))
             if verbose_level is not 0:
-                data = json.dumps({'HOST': target, 'USERNAME': '', 'PASSWORD': '', 'PORT': '', 'TYPE': 'dir_scan',
-                                       'DESCRIPTION': messages(language, 94), 'TIME': now(), 'CATEGORY': "scan",
-                                       'SCAN_ID': scan_id, 'SCAN_CMD': scan_cmd})
+                data = json.dumps({'HOST': target, 'USERNAME': '', 'PASSWORD': '', 'PORT': '', 'TYPE': 'dir_scan', 
+                    'DESCRIPTION': messages(language, 94), 'TIME': now(), 'CATEGORY': "scan", 
+                    'SCAN_ID': scan_id, 'SCAN_CMD': scan_cmd})
                 __log_into_file(log_in_file, 'a', data)
         os.remove(thread_tmp_filename)
     else:

--- a/lib/scan/dir/engine.py
+++ b/lib/scan/dir/engine.py
@@ -17,6 +17,7 @@ from core.targets import target_to_host
 from lib.icmp.engine import do_one as do_one_ping
 from lib.socks_resolver.engine import getaddrinfo
 from core._time import now
+from core.log import __log_into_file
 from core._die import __die_failure
 
 
@@ -81,25 +82,21 @@ def check(target, user_agent, timeout_sec, log_in_file, language, time_sleep, th
             content = content.decode('utf8')
         if r.status_code in status_codes:
             info(messages(language, 38).format(target, r.status_code, r.reason))
-            thread_write = open(thread_tmp_filename, 'w')
-            thread_write.write('0')
-            thread_write.close()
-            save = open(log_in_file, 'a')
-            save.write(json.dumps({'HOST': target_to_host(target), 'USERNAME': '', 'PASSWORD': '',
+            __log_into_file(thread_tmp_filename, 'w', '0')
+            data = json.dumps({'HOST': target_to_host(target), 'USERNAME': '', 'PASSWORD': '',
                                    'PORT': int(target.rsplit(':')[2].rsplit('/')[0]), 'TYPE': 'dir_scan',
                                    'DESCRIPTION': messages(language, 38).format(target, r.status_code, r.reason),
-                                   'TIME': now(), 'CATEGORY': "scan", 'SCAN_ID': scan_id, 'SCAN_CMD': scan_cmd}) + '\n')
-            save.close()
+                                   'TIME': now(), 'CATEGORY': "scan", 'SCAN_ID': scan_id, 'SCAN_CMD': scan_cmd})
+            __log_into_file(log_in_file, 'a', data)
             if r.status_code is 200:
                 for dlmsg in directory_listing_msgs:
                     if dlmsg in content:
                         info(messages(language, 104).format(target))
-                        save = open(log_in_file, 'a')
-                        save.write(json.dumps({'HOST': target_to_host(target), 'USERNAME': '', 'PASSWORD': '',
+                        data = json.dumps({'HOST': target_to_host(target), 'USERNAME': '', 'PASSWORD': '',
                                                'PORT': int(target.rsplit(':')[1].rsplit('/')[0]), 'TYPE': 'dir_scan',
                                                'DESCRIPTION': messages(language, 104).format(target), 'TIME': now(),
-                                               'CATEGORY': "scan", 'SCAN_ID': scan_id, 'SCAN_CMD': scan_cmd}) + '\n')
-                        save.close()
+                                               'CATEGORY': "scan", 'SCAN_ID': scan_id, 'SCAN_CMD': scan_cmd})
+                        __log_into_file(log_in_file, 'a', data)
                         break
         return True
     except:
@@ -205,9 +202,7 @@ def start(target, users, passwds, ports, timeout_sec, thread_number, num, total,
         total_req = len(extra_requirements["dir_scan_list"]) * len(ports)
         thread_tmp_filename = 'tmp/thread_tmp_' + ''.join(
             random.choice(string.ascii_letters + string.digits) for _ in range(20))
-        thread_write = open(thread_tmp_filename, 'w')
-        thread_write.write('1')
-        thread_write.close()
+        __log_into_file(thread_tmp_filename, 'w', '1')
         trying = 0
         for port in ports:
             port = int(port)
@@ -272,11 +267,10 @@ def start(target, users, passwds, ports, timeout_sec, thread_number, num, total,
         if thread_write is 1:
             info(messages(language, 108).format(target, ",".join(map(str, ports))))
             if verbose_level is not 0:
-                save = open(log_in_file, 'a')
-                save.write(json.dumps({'HOST': target, 'USERNAME': '', 'PASSWORD': '', 'PORT': '', 'TYPE': 'dir_scan',
+                data = json.dumps({'HOST': target, 'USERNAME': '', 'PASSWORD': '', 'PORT': '', 'TYPE': 'dir_scan',
                                        'DESCRIPTION': messages(language, 94), 'TIME': now(), 'CATEGORY': "scan",
-                                       'SCAN_ID': scan_id, 'SCAN_CMD': scan_cmd}) + '\n')
-                save.close()
+                                       'SCAN_ID': scan_id, 'SCAN_CMD': scan_cmd})
+                __log_into_file(log_in_file, 'a', data)
         os.remove(thread_tmp_filename)
     else:
         warn(messages(language, 69).format('dir_scan', target))

--- a/lib/scan/subdomain/engine.py
+++ b/lib/scan/subdomain/engine.py
@@ -15,6 +15,7 @@ from core.alert import *
 from lib.icmp.engine import do_one as do_one_ping
 from lib.socks_resolver.engine import getaddrinfo
 from core._time import now
+from core.log import __log_into_file
 
 
 def extra_requirements_dict():
@@ -70,9 +71,7 @@ def __cert_spotter(target, timeout_sec, log_in_file, time_sleep, language, verbo
         else:
             # warn 403
             pass
-        f = open(thread_tmp_filename, 'a')
-        f.write('\n'.join(subs) + '\n')
-        f.close()
+        __log_into_file(thread_tmp_filename, 'a', '\n'.join(subs))
         return subs
     except:
         return []
@@ -113,9 +112,7 @@ def __google_dig(target, timeout_sec, log_in_file, time_sleep, language, verbose
         else:
             # warn 403
             pass
-        f = open(thread_tmp_filename, 'a')
-        f.write('\n'.join(subs) + '\n')
-        f.close()
+        __log_into_file(thread_tmp_filename, 'a','\n'.join(subs))
         return subs
     except:
         return []
@@ -170,9 +167,7 @@ def __netcraft(target, timeout_sec, log_in_file, time_sleep, language, verbose_l
                     results.content)[0]
             except:
                 break
-        f = open(thread_tmp_filename, 'a')
-        f.write('\n'.join(subs) + '\n')
-        f.close()
+        __log_into_file(thread_tmp_filename, 'a', '\n'.join(subs))
         return subs
     except:
         return []
@@ -215,9 +210,7 @@ def __threatcrowd(target, timeout_sec, log_in_file, time_sleep, language, verbos
         else:
             # warn 403
             pass
-        f = open(thread_tmp_filename, 'a')
-        f.write('\n'.join(subs) + '\n')
-        f.close()
+        __log_into_file(thread_tmp_filename, 'a', '\n'.join(subs))
         return subs
     except:
         return []
@@ -257,9 +250,7 @@ def __dnsdumpster(target, timeout_sec, log_in_file, time_sleep, language, verbos
         else:
             # warn 403
             pass
-        f = open(thread_tmp_filename, 'a')
-        f.write('\n'.join(subs) + '\n')
-        f.close()
+        __log_into_file(thread_tmp_filename, 'a', '\n'.join(subs))
         return subs
     except:
         return []
@@ -304,9 +295,7 @@ def __comodo_crt(target, timeout_sec, log_in_file, time_sleep, language, verbose
         else:
             # warn 403
             pass
-        f = open(thread_tmp_filename, 'a')
-        f.write('\n'.join(subs) + '\n')
-        f.close()
+        __log_into_file(thread_tmp_filename, 'a', '\n'.join(subs))
         return subs
     except:
         return []
@@ -354,9 +343,7 @@ def __virustotal(target, timeout_sec, log_in_file, time_sleep, language, verbose
         else:
             # warn 403
             pass
-        f = open(thread_tmp_filename, 'a')
-        f.write('\n'.join(subs) + '\n')
-        f.close()
+        __log_into_file(thread_tmp_filename, 'a', '\n'.join(subs))
         return subs
     except:
         return []
@@ -398,9 +385,7 @@ def __ptrarchive(target, timeout_sec, log_in_file, time_sleep, language, verbose
         else:
             # warn 403
             pass
-        f = open(thread_tmp_filename, 'a')
-        f.write('\n'.join(subs) + '\n')
-        f.close()
+        __log_into_file(thread_tmp_filename, 'a', '\n'.join(subs))
         return subs
     except:
         return []
@@ -570,22 +555,20 @@ def start(target, users, passwds, ports, timeout_sec, thread_number, num, total,
         if len(subs) is 0:
             info(messages(language, 163))
         if len(subs) is not 0:
-            save = open(log_in_file, 'a')
             for sub in subs:
                 info(messages(language, 135).format(sub))
-                save.write(
+                data = 
                     json.dumps({'HOST': target, 'USERNAME': '', 'PASSWORD': '', 'PORT': '', 'TYPE': 'subdomain_scan',
                                 'DESCRIPTION': sub, 'TIME': now(), 'CATEGORY': "scan", 'SCAN_ID': scan_id,
-                                'SCAN_CMD': scan_cmd}) + '\n')
-            save.close()
+                                'SCAN_CMD': scan_cmd})
+                __log_into_file(log_in_file, 'a', data)
         if len(subs) is 0 and verbose_level is not 0:
-            save = open(log_in_file, 'a')
-            save.write(
+            data = 
                 json.dumps({'HOST': target, 'USERNAME': '', 'PASSWORD': '', 'PORT': '', 'TYPE': 'subdomain_scan',
                             'DESCRIPTION': messages(language, 135).format(len(subs), ', '.join(subs)
                             if len(subs) > 0 else 'None'), 'TIME': now(), 'CATEGORY': "scan", 'SCAN_ID': scan_id,
-                            'SCAN_CMD': scan_cmd}) + '\n')
-            save.close()
+                            'SCAN_CMD': scan_cmd})
+            __log_into_file( log_in_file, 'a', data)
         return subs
     else:
         warn(messages(language, 69).format('subdomain_scan', target))

--- a/lib/scan/subdomain/engine.py
+++ b/lib/scan/subdomain/engine.py
@@ -557,17 +557,14 @@ def start(target, users, passwds, ports, timeout_sec, thread_number, num, total,
         if len(subs) is not 0:
             for sub in subs:
                 info(messages(language, 135).format(sub))
-                data = 
-                    json.dumps({'HOST': target, 'USERNAME': '', 'PASSWORD': '', 'PORT': '', 'TYPE': 'subdomain_scan',
-                                'DESCRIPTION': sub, 'TIME': now(), 'CATEGORY': "scan", 'SCAN_ID': scan_id,
-                                'SCAN_CMD': scan_cmd})
+                data = json.dumps({'HOST': target, 'USERNAME': '', 'PASSWORD': '', 'PORT': '', 'TYPE': 'subdomain_scan', 
+                    'DESCRIPTION': sub, 'TIME': now(), 'CATEGORY': "scan", 'SCAN_ID': scan_id, 'SCAN_CMD': scan_cmd})
                 __log_into_file(log_in_file, 'a', data)
         if len(subs) is 0 and verbose_level is not 0:
-            data = 
-                json.dumps({'HOST': target, 'USERNAME': '', 'PASSWORD': '', 'PORT': '', 'TYPE': 'subdomain_scan',
-                            'DESCRIPTION': messages(language, 135).format(len(subs), ', '.join(subs)
-                            if len(subs) > 0 else 'None'), 'TIME': now(), 'CATEGORY': "scan", 'SCAN_ID': scan_id,
-                            'SCAN_CMD': scan_cmd})
+            data = json.dumps({'HOST': target, 'USERNAME': '', 'PASSWORD': '', 'PORT': '', 'TYPE': 'subdomain_scan', 
+                'DESCRIPTION': messages(language, 135).format(len(subs), ', '.join(subs) 
+                    if len(subs) > 0 else 'None'), 'TIME': now(), 'CATEGORY': "scan", 'SCAN_ID': scan_id,
+                'SCAN_CMD': scan_cmd})
             __log_into_file( log_in_file, 'a', data)
         return subs
     else:

--- a/lib/scan/tcp_connect_port/engine.py
+++ b/lib/scan/tcp_connect_port/engine.py
@@ -131,10 +131,9 @@ def connect(host, port, timeout_sec, log_in_file, language, time_sleep, thread_t
             s.connect((host, port))
         s.close()
         info(messages(language, 80).format(host, port))
-        data = 
-            json.dumps({'HOST': host, 'USERNAME': '', 'PASSWORD': '', 'PORT': port, 'TYPE': 'tcp_connect_port_scan',
-                        'DESCRIPTION': messages(language, 79), 'TIME': now(), 'CATEGORY': "scan", 'SCAN_ID': scan_id,
-                        'SCAN_CMD': scan_cmd}) + '\n')
+        data = json.dumps({'HOST': host, 'USERNAME': '', 'PASSWORD': '', 'PORT': port, 'TYPE': 'tcp_connect_port_scan', 
+            'DESCRIPTION': messages(language, 79), 'TIME': now(), 'CATEGORY': "scan", 'SCAN_ID': scan_id, 
+            'SCAN_CMD': scan_cmd}) + '\n')
         __log_into_file(log_in_file, 'a', data)
         __log_into_file(thread_tmp_filename, 'w', '0')
         return True
@@ -218,10 +217,9 @@ def start(target, users, passwds, ports, timeout_sec, thread_number, num, total,
                 break
         thread_write = int(open(thread_tmp_filename).read().rsplit()[0])
         if thread_write is 1 and verbose_level is not 0:
-            data = 
-                json.dumps({'HOST': target, 'USERNAME': '', 'PASSWORD': '', 'PORT': '', 'TYPE': 'tcp_connect_port_scan',
-                            'DESCRIPTION': messages(language, 94), 'TIME': now(), 'CATEGORY': "scan",
-                            'SCAN_ID': scan_id, 'SCAN_CMD': scan_cmd})
+            data = json.dumps({'HOST': target, 'USERNAME': '', 'PASSWORD': '', 'PORT': '', 'TYPE': 'tcp_connect_port_scan', 
+                'DESCRIPTION': messages(language, 94), 'TIME': now(), 'CATEGORY': "scan", 
+                'SCAN_ID': scan_id, 'SCAN_CMD': scan_cmd})
             __log_into_file(log_in_file, 'a', data)
         os.remove(thread_tmp_filename)
 

--- a/lib/scan/tcp_connect_port/engine.py
+++ b/lib/scan/tcp_connect_port/engine.py
@@ -118,11 +118,16 @@ def connect(host, port, timeout_sec, log_in_file, language, time_sleep, thread_t
                 socks.set_default_proxy(socks_version, str(socks_proxy.rsplit(':')[0]), int(socks_proxy.rsplit(':')[1]))
                 socket.socket = socks.socksocket
                 socket.getaddrinfo = getaddrinfo
-       
-        s = socket.socket(socket.AF_INET6, socket.SOCK_STREAM,0)
+        if target_type(host) == "SINGLE_IPv6":
+            s = socket.socket(socket.AF_INET6, socket.SOCK_STREAM, 0)
+        else:
+            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         if timeout_sec is not None:
             s.settimeout(timeout_sec)
-        s.connect((host, port,0,0))
+        if target_type(host) == "SINGLE_IPv6":
+            s.connect((host, port, 0, 0))
+        else:
+            s.connect((host, port))
         s.close()
         info(messages(language, 80).format(host, port))
         save = open(log_in_file, 'a')
@@ -142,7 +147,8 @@ def connect(host, port, timeout_sec, log_in_file, language, time_sleep, thread_t
 def start(target, users, passwds, ports, timeout_sec, thread_number, num, total, log_in_file, time_sleep, language,
           verbose_level, socks_proxy, retries, ping_flag, methods_args, scan_id,
           scan_cmd):  # Main function
-    if target_type(target) != 'SINGLE_IPv4' or target_type(target) != 'DOMAIN' or target_type(target) != 'HTTP' or target_type(target)!= 'SINGLE_IPv6':
+    if target_type(target) != 'SINGLE_IPv4' or target_type(target) != 'DOMAIN' or target_type(
+            target) != 'HTTP' or target_type(target) != 'SINGLE_IPv6':
         # requirements check
         new_extra_requirements = extra_requirements_dict()
         if methods_args is not None:
@@ -184,7 +190,6 @@ def start(target, users, passwds, ports, timeout_sec, thread_number, num, total,
         thread_write.close()
         trying = 0
         for port in ports:
-            port = int(port)
             t = threading.Thread(target=connect,
                                  args=(target, int(port), timeout_sec, log_in_file, language, time_sleep,
                                        thread_tmp_filename, socks_proxy, scan_id, scan_cmd))

--- a/lib/scan/tcp_connect_port/engine.py
+++ b/lib/scan/tcp_connect_port/engine.py
@@ -15,6 +15,7 @@ from core.targets import target_to_host
 from lib.icmp.engine import do_one as do_one_ping
 from lib.socks_resolver.engine import getaddrinfo
 from core._time import now
+from core.log import __log_into_file
 
 
 def extra_requirements_dict():
@@ -130,15 +131,12 @@ def connect(host, port, timeout_sec, log_in_file, language, time_sleep, thread_t
             s.connect((host, port))
         s.close()
         info(messages(language, 80).format(host, port))
-        save = open(log_in_file, 'a')
-        save.write(
+        data = 
             json.dumps({'HOST': host, 'USERNAME': '', 'PASSWORD': '', 'PORT': port, 'TYPE': 'tcp_connect_port_scan',
                         'DESCRIPTION': messages(language, 79), 'TIME': now(), 'CATEGORY': "scan", 'SCAN_ID': scan_id,
                         'SCAN_CMD': scan_cmd}) + '\n')
-        save.close()
-        thread_write = open(thread_tmp_filename, 'w')
-        thread_write.write('0')
-        thread_write.close()
+        __log_into_file(log_in_file, 'a', data)
+        __log_into_file(thread_tmp_filename, 'w', '0')
         return True
     except:
         return False
@@ -185,9 +183,7 @@ def start(target, users, passwds, ports, timeout_sec, thread_number, num, total,
         total_req = len(ports)
         thread_tmp_filename = 'tmp/thread_tmp_' + ''.join(
             random.choice(string.ascii_letters + string.digits) for _ in range(20))
-        thread_write = open(thread_tmp_filename, 'w')
-        thread_write.write('1')
-        thread_write.close()
+        __log_into_file(thread_tmp_filename, 'w', '1')
         trying = 0
         for port in ports:
             t = threading.Thread(target=connect,
@@ -222,12 +218,11 @@ def start(target, users, passwds, ports, timeout_sec, thread_number, num, total,
                 break
         thread_write = int(open(thread_tmp_filename).read().rsplit()[0])
         if thread_write is 1 and verbose_level is not 0:
-            save = open(log_in_file, 'a')
-            save.write(
+            data = 
                 json.dumps({'HOST': target, 'USERNAME': '', 'PASSWORD': '', 'PORT': '', 'TYPE': 'tcp_connect_port_scan',
                             'DESCRIPTION': messages(language, 94), 'TIME': now(), 'CATEGORY': "scan",
-                            'SCAN_ID': scan_id, 'SCAN_CMD': scan_cmd}) + '\n')
-            save.close()
+                            'SCAN_ID': scan_id, 'SCAN_CMD': scan_cmd})
+            __log_into_file(log_in_file, 'a', data)
         os.remove(thread_tmp_filename)
 
     else:

--- a/lib/scan/viewdns_reverse_ip_lookup/engine.py
+++ b/lib/scan/viewdns_reverse_ip_lookup/engine.py
@@ -97,17 +97,15 @@ def start(target, users, passwds, ports, timeout_sec, thread_number, num, total,
         if len(_values) > 0:
             for domain in _values:
                 info(messages(language, 114).format(domain))
-                data = json.dumps(
-                    {'HOST': target, 'USERNAME': '', 'PASSWORD': '', 'PORT': '',
-                     'TYPE': 'viewdns_reverse_ip_lookup_scan', 'DESCRIPTION': domain,
-                     'TIME': now(), 'CATEGORY': "scan", 'SCAN_ID': scan_id, 'SCAN_CMD': scan_cmd})
+                data = json.dumps({'HOST': target, 'USERNAME': '', 'PASSWORD': '', 'PORT': '', 
+                    'TYPE': 'viewdns_reverse_ip_lookup_scan', 'DESCRIPTION': domain, 
+                    'TIME': now(), 'CATEGORY': "scan", 'SCAN_ID': scan_id, 'SCAN_CMD': scan_cmd})
                 __log_into_file(log_in_file, 'a', data)
         if verbose_level is not 0:
-            data = json.dumps(
-                {'HOST': target, 'USERNAME': '', 'PASSWORD': '', 'PORT': '', 'TYPE': 'viewdns_reverse_ip_lookup_scan',
-                 'DESCRIPTION': messages(language, 114).format(len(_values), ", ".join(_values) if len(
-                     _values) > 0 else "None"), 'TIME': now(), 'CATEGORY': "scan", 'SCAN_ID': scan_id,
-                 'SCAN_CMD': scan_cmd})
+            data = json.dumps({'HOST': target, 'USERNAME': '', 'PASSWORD': '', 'PORT': '', 'TYPE': 'viewdns_reverse_ip_lookup_scan', 
+                'DESCRIPTION': messages(language, 114).format(len(_values), ", ".join(_values) if len(
+                    _values) > 0 else "None"), 'TIME': now(), 'CATEGORY': "scan", 'SCAN_ID': scan_id, 
+                'SCAN_CMD': scan_cmd})
             __log_into_file('log.txt', 'a', data)
     else:
         warn(messages(language, 69).format('viewdns_reverse_ip_lookup_scan', target))

--- a/lib/scan/viewdns_reverse_ip_lookup/engine.py
+++ b/lib/scan/viewdns_reverse_ip_lookup/engine.py
@@ -11,6 +11,7 @@ from xml.etree import ElementTree as ET
 from core.alert import *
 from core.targets import target_type
 from core.targets import target_to_host
+from core.log import __log_into_file
 from lib.icmp.engine import do_one as do_one_ping
 from lib.socks_resolver.engine import getaddrinfo
 
@@ -94,21 +95,19 @@ def start(target, users, passwds, ports, timeout_sec, thread_number, num, total,
         if len(_values) is 0:
             info(messages(language, 164))
         if len(_values) > 0:
-            save = open(log_in_file, 'a')
             for domain in _values:
                 info(messages(language, 114).format(domain))
-                save.write(json.dumps(
+                data = json.dumps(
                     {'HOST': target, 'USERNAME': '', 'PASSWORD': '', 'PORT': '',
                      'TYPE': 'viewdns_reverse_ip_lookup_scan', 'DESCRIPTION': domain,
-                     'TIME': now(), 'CATEGORY': "scan", 'SCAN_ID': scan_id, 'SCAN_CMD': scan_cmd}) + '\n')
-            save.close()
+                     'TIME': now(), 'CATEGORY': "scan", 'SCAN_ID': scan_id, 'SCAN_CMD': scan_cmd})
+                __log_into_file(log_in_file, 'a', data)
         if verbose_level is not 0:
-            save = open(log_in_file, 'a')
-            save.write(json.dumps(
+            data = json.dumps(
                 {'HOST': target, 'USERNAME': '', 'PASSWORD': '', 'PORT': '', 'TYPE': 'viewdns_reverse_ip_lookup_scan',
                  'DESCRIPTION': messages(language, 114).format(len(_values), ", ".join(_values) if len(
                      _values) > 0 else "None"), 'TIME': now(), 'CATEGORY': "scan", 'SCAN_ID': scan_id,
-                 'SCAN_CMD': scan_cmd}) + '\n')
-            save.close()
+                 'SCAN_CMD': scan_cmd})
+            __log_into_file('log.txt', 'a', data)
     else:
         warn(messages(language, 69).format('viewdns_reverse_ip_lookup_scan', target))

--- a/lib/vuln/heartbleed/engine.py
+++ b/lib/vuln/heartbleed/engine.py
@@ -22,6 +22,7 @@ from core.targets import target_to_host
 from lib.icmp.engine import do_one as do_one_ping
 from lib.socks_resolver.engine import getaddrinfo
 from core._time import now
+from core.log import __log_into_file
 
 
 def extra_requirements_dict():
@@ -189,15 +190,12 @@ def __heartbleed(target, port, timeout_sec, log_in_file, language, time_sleep,
     if bleed(target, port, timeout_sec, log_in_file, language, time_sleep,
              thread_tmp_filename, socks_proxy, scan_id, scan_cmd):
         info(messages(language, 140).format(target, port, 'heartbleed'))
-        thread_write = open(thread_tmp_filename, 'w')
-        thread_write.write('0')
-        thread_write.close()
-        save = open(log_in_file, 'a')
-        save.write(
+        __log_into_file(thread_tmp_filename, 'w', '0')
+        data = 
             json.dumps({'HOST': target, 'USERNAME': '', 'PASSWORD': '', 'PORT': port, 'TYPE': 'heartbleed_vuln',
                         'DESCRIPTION': messages(language, 139).format('heartbleed'), 'TIME': now(), 'CATEGORY': "vuln",
-                        'SCAN_ID': scan_id, 'SCAN_CMD': scan_cmd}) + '\n')
-        save.close()
+                        'SCAN_ID': scan_id, 'SCAN_CMD': scan_cmd})
+        __log_into_file(log_in_file, 'a', data)
         return True
     else:
         return False
@@ -243,9 +241,7 @@ def start(target, users, passwds, ports, timeout_sec, thread_number, num, total,
         total_req = len(ports)
         thread_tmp_filename = 'tmp/thread_tmp_' + ''.join(
             random.choice(string.ascii_letters + string.digits) for _ in range(20))
-        thread_write = open(thread_tmp_filename, 'w')
-        thread_write.write('1')
-        thread_write.close()
+        __log_into_file(thread_tmp_filename, 'w', '1')
         trying = 0
 
         for port in ports:
@@ -282,12 +278,11 @@ def start(target, users, passwds, ports, timeout_sec, thread_number, num, total,
         thread_write = int(open(thread_tmp_filename).read().rsplit()[0])
         if thread_write is 1 and verbose_level is not 0:
             info(messages(language, 141).format('heartbleed'))
-            save = open(log_in_file, 'a')
-            save.write(
+            data = 
                 json.dumps({'HOST': target, 'USERNAME': '', 'PASSWORD': '', 'PORT': '', 'TYPE': 'heartbleed_vuln',
                             'DESCRIPTION': messages(language, 141).format('heartbleed'), 'TIME': now(),
-                            'CATEGORY': "scan", 'SCAN_ID': scan_id, 'SCAN_CMD': scan_cmd}) + '\n')
-            save.close()
+                            'CATEGORY': "scan", 'SCAN_ID': scan_id, 'SCAN_CMD': scan_cmd})
+            __log_into_file(log_in_file, 'a', data)
         os.remove(thread_tmp_filename)
 
     else:

--- a/lib/vuln/heartbleed/engine.py
+++ b/lib/vuln/heartbleed/engine.py
@@ -191,10 +191,9 @@ def __heartbleed(target, port, timeout_sec, log_in_file, language, time_sleep,
              thread_tmp_filename, socks_proxy, scan_id, scan_cmd):
         info(messages(language, 140).format(target, port, 'heartbleed'))
         __log_into_file(thread_tmp_filename, 'w', '0')
-        data = 
-            json.dumps({'HOST': target, 'USERNAME': '', 'PASSWORD': '', 'PORT': port, 'TYPE': 'heartbleed_vuln',
-                        'DESCRIPTION': messages(language, 139).format('heartbleed'), 'TIME': now(), 'CATEGORY': "vuln",
-                        'SCAN_ID': scan_id, 'SCAN_CMD': scan_cmd})
+        data = json.dumps({'HOST': target, 'USERNAME': '', 'PASSWORD': '', 'PORT': port, 'TYPE': 'heartbleed_vuln', 
+            'DESCRIPTION': messages(language, 139).format('heartbleed'), 'TIME': now(), 'CATEGORY': "vuln", 
+            'SCAN_ID': scan_id, 'SCAN_CMD': scan_cmd})
         __log_into_file(log_in_file, 'a', data)
         return True
     else:
@@ -278,10 +277,9 @@ def start(target, users, passwds, ports, timeout_sec, thread_number, num, total,
         thread_write = int(open(thread_tmp_filename).read().rsplit()[0])
         if thread_write is 1 and verbose_level is not 0:
             info(messages(language, 141).format('heartbleed'))
-            data = 
-                json.dumps({'HOST': target, 'USERNAME': '', 'PASSWORD': '', 'PORT': '', 'TYPE': 'heartbleed_vuln',
-                            'DESCRIPTION': messages(language, 141).format('heartbleed'), 'TIME': now(),
-                            'CATEGORY': "scan", 'SCAN_ID': scan_id, 'SCAN_CMD': scan_cmd})
+            data = json.dumps({'HOST': target, 'USERNAME': '', 'PASSWORD': '', 'PORT': '', 'TYPE': 'heartbleed_vuln', 
+                'DESCRIPTION': messages(language, 141).format('heartbleed'), 'TIME': now(), 
+                'CATEGORY': "scan", 'SCAN_ID': scan_id, 'SCAN_CMD': scan_cmd})
             __log_into_file(log_in_file, 'a', data)
         os.remove(thread_tmp_filename)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ PySocks
 win_inet_pton
 pyOpenSSL
 flask
-filelock
+lockfile


### PR DESCRIPTION
Regarding #22 

Created ` __log_into_file(filename, mode, data)` in [core/log.py](https://github.com/avhvr/OWASP-Nettacker/blob/master/core/log.py#L88) 
used [filelock](https://filelock.readthedocs.io/en/latest/) module (works on windows too)

changed blocks of code in following files: 

- lib/brute/smtp/engine.py
- lib/brute/ssh/engine.py
- lib/brute/ftp/engine.py
- lib/vuln/heartbleed/engine.py
- lib/scan/dir/engine.py
- lib/scan/viewdns_reverse_ip_lookup/engine.py
- lib/scan/tcp_connect_port/engine.py
- lib/scan/subdomain/engine.py

Feedback is appreciated
_________________
**OS**: `KDE neon LTS`

**OS Version**: `5.8`

**Python Version**: `3.5.2`