### PR TITLE
windows 10 bug fixed

### DIFF
--- a/core/log.py
+++ b/core/log.py
@@ -86,7 +86,7 @@ def sort_logs(log_in_file, language, graph_flag, scan_id, scan_cmd, verbose_leve
         report_type = "JSON"
         data = json.dumps(JSON_Data)
         events_num = len(JSON_Data)
-        __log_into_file(log_in_file, 'wb', data, language, final=True)
+        __log_into_file(log_in_file, 'w', data, language, final=True)
     else:
         graph_flag = ""
         report_type = "TEXT"
@@ -133,13 +133,13 @@ def __log_into_file(filename, mode, data, language, final=False):
         if not final:
             flock = lockfile.FileLock(filename)
             flock.acquire()
-        with open(filename, mode) as save:
+        with open(filename, mode, encoding='utf-8') as save:
             save.write(data + '\n')
         if not final:
             flock.release()
     else:
         if final:
-            with open(filename, mode) as save:
+            with open(filename, mode, encoding='utf-8') as save:
                 save.write(data + '\n')
         else:
             submit_logs_to_db(language, data)

--- a/core/log.py
+++ b/core/log.py
@@ -18,7 +18,7 @@ from api.__database import __logs_to_report
 from core.config_builder import default_paths
 from core.config import _paths
 from core.config_builder import _builder
-
+from core.compatible import version
 
 def build_graph(graph_flag, language, data, _HOST, _USERNAME, _PASSWORD, _PORT, _TYPE, _DESCRIPTION):
     info(messages(language, 88))
@@ -129,17 +129,39 @@ def sort_logs(log_in_file, language, graph_flag, scan_id, scan_cmd, verbose_leve
 
 
 def __log_into_file(filename, mode, data, language, final=False):
-    if _builder(_paths(), default_paths())["tmp_path"] in filename:
-        if not final:
-            flock = lockfile.FileLock(filename)
-            flock.acquire()
-        with open(filename, mode, encoding='utf-8') as save:
-            save.write(data + '\n')
-        if not final:
-            flock.release()
+
+    if version() is 2:
+    
+      if _builder(_paths(), default_paths())["tmp_path"] in filename:
+          if not final:
+              flock = lockfile.FileLock(filename)
+              flock.acquire()
+          with open(filename, mode) as save:
+              save.write(data + '\n')
+          if not final:
+              flock.release()
+      else:
+          if final:
+              with open(filename, mode) as save:
+                  save.write(data + '\n')
+          else:
+              submit_logs_to_db(language, data)
+
     else:
-        if final:
-            with open(filename, mode, encoding='utf-8') as save:
-                save.write(data + '\n')
-        else:
-            submit_logs_to_db(language, data)
+
+      if _builder(_paths(), default_paths())["tmp_path"] in filename:
+          if not final:
+              flock = lockfile.FileLock(filename)
+              flock.acquire()
+          with open(filename, mode, encoding='utf-8') as save:
+              save.write(data + '\n')
+          if not final:
+              flock.release()
+      else:
+          if final:
+              with open(filename, mode, encoding='utf-8') as save:
+                  save.write(data + '\n')
+          else:
+              submit_logs_to_db(language, data)
+
+              


### PR DESCRIPTION
__log_into_file function is creating an error
	

It's due to the default behaviour of open in Python 3. By default, Python 3 will open files in Text mode, which means that it also has to apply a text decoding, such as utf-8 or ASCII, for every character it reads.

Python will use your locale to determine the most suitable encoding. On OS X and Linux, this is usually UTF-8. On Windows, it'll use an 8-bit character set, such windows-1252, to match the behaviour of Notepad.

so i added encoding with open. this fixed the error.

Describe your changes or your new module and let us know which OS and Python version you tested on.
_________________
**OS**: `windows`

**OS Version**: `windows 10`

**Python Version**: `3.6`
