### PR TITLE
Fix #91

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:2.7-alpine
-RUN apk add --no-cache python pkgconfig python-dev openssl-dev libffi-dev musl-dev make gcc git
+RUN apk add --no-cache python pkgconfig python-dev openssl-dev libffi-dev musl-dev make gcc git curl-dev librtmp
 WORKDIR /usr/src/owaspnettacker
 RUN git clone https://github.com/viraintel/OWASP-Nettacker.git .
 RUN pip install --no-cache-dir -r requirements.txt


### PR DESCRIPTION
This fixes issue #91. Apparently pycurl needed these packages curl-dev and librtmp.
_________________
**OS**: `Ubuntu`

**OS Version**: `17.10`

**Python Version**: `2.7`
